### PR TITLE
Fix write_metrics in mkarv

### DIFF
--- a/src/scripts/mkarv
+++ b/src/scripts/mkarv
@@ -554,7 +554,7 @@ def write_metrics(indent, metrics):
 
     with gzip.open(output_filename, 'wt') as output_file:
         try:
-            new_json = json.dumps([metrics], output_file, sort_keys=True, indent=indent, ensure_ascii=False)
+            new_json = json.dumps([metrics], sort_keys=True, indent=indent, ensure_ascii=False)
             output_file.write(new_json)
         except Exception as e:
             print('Could not write file {}: {}'.format(output_filename, e), file=sys.stderr)


### PR DESCRIPTION
In a previous commit (2af7b8401b1c6e813467804914534c127141da1d), the `json.dump()` line was changed to `json.dumps()`, but `json.dumps()` does not accept the output file as a parameter.

This script was failing to run for me, and this change fixes it.