### PR TITLE
Update Debian packaging

### DIFF
--- a/MAINTENANCE.rst
+++ b/MAINTENANCE.rst
@@ -1,0 +1,53 @@
+############################
+Release management for ataqv
+############################
+
+Creating ataqv installation packages
+====================================
+
+Generic tarball
+---------------
+
+You can create a simple distribution tarball with::
+
+  make dist
+
+That will create a ``.tar.gz`` file in the ``build`` subdirectory of the
+source tree, which can be extracted and used on a system running the
+same operating system and with sufficiently compatible versions of
+shared library dependencies. To eliminate the shared library
+constraints, you can try to build a static distribution with::
+
+  make dist-static
+
+However, static compilation has only been tried on Linux (RHEL 6;
+Debian Stretch and Buster), and it may not work at all on your
+distribution. You will almost certainly need HTSlib built without cURL
+support, as some of the library dependencies are not available as
+shared libraries. Supply the path to your custom HTSlib with ``make
+HTSLIB_STATIC_DIR=/path dist-static``.
+
+Debian package
+--------------
+
+You can produce a Debian package with ``make deb``. To produce a
+Debian package with ataqv statically linked, minimizing the risk of a
+target system not having the proper versions of shared libraries, try
+``make deb-static``. The same caveats and constraints of static
+compilation described above apply here as well.
+
+RPM
+---
+
+You can package ataqv in an RPM by running ``make rpm``. Again,
+there's a static variant you can try with ``make rpm-static`` to
+maximize compatibility.
+
+Making a new ataqv release on GitHub
+====================================
+
+Visit https://github.com/ParkerLab/ataqv/releases and click the `Draft
+a new release` button. Fill in the form, entering the new version and
+selecting the branch or commit you wish to tag with it, describing the
+content of the release and attaching any binary packages you've built
+with the instructions above.

--- a/README.rst
+++ b/README.rst
@@ -66,10 +66,10 @@ Binary packages (Linux only)
 ============================
 
 We provide several Linux binary packages under `recent releases on
-Github`_. Install ``.deb`` or ``.rpm`` files with ``dpkg`` or ``yum``,
-or download and extract the ``ataqv-x.x.x.tar.gz`` file and add the
-full path to the resulting ``ataqv-x.x.x/bin`` subdirectory to your
-PATH environment variable.
+Github`_. Install ``.deb`` files with ``dpkg``, ``.rpm`` files with
+``dnf`` or ``yum``, or download and extract the ``ataqv-x.x.x.tar.gz``
+file and add the full path to the resulting ``ataqv-x.x.x/bin``
+subdirectory to your PATH environment variable.
 
 Homebrew (Mac or Linux)
 =======================
@@ -178,26 +178,6 @@ can install to the modules tree by defining the ``MODULES_ROOT`` and
 
 And then you should be able to run ``module load ataqv`` to have
 everything available in your environment.
-
-You can create a distribution tarball with::
-
-  make dist
-
-It will create a .tar.gz file in the ``build`` subdirectory of the
-source tree. Extract that anywhere and add the ``bin`` subdirectory to
-your PATH environment variable. To use the distribution on another
-machine, that machine must have the same shared libraries as your
-build machine. If that's not possible, you can try to build a static
-distribution with::
-
-  make dist-static
-
-However, static compilation has only been tried on Linux (RHEL 6;
-Debian testing (Stretch) and unstable), and it may not work at all on
-your distribution. You will almost certainly need HTSlib built without
-cURL support, as some of the library dependencies are not available as
-shared libraries. Supply the path to your custom HTSlib with ``make
-HTSLIB_STATIC_DIR=/path static``.
 
 *****
 Usage

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+ataqv (1.1.1-1) unstable; urgency=low
+
+  * Speed up TSS coverage/enrichment calculations when multiple read
+    groups are present
+
+  * TSS coverage/enrichment was previously (incorrectly) the same
+    for all read groups in the bam file. That's no longer the case.
+
+  * Fix indentation.
+
+ -- Parker Lab Software <parkerlab-software@umich.edu>  Mon, 28 Oct 2019 10:30:00 -0500
+
 ataqv (1.1.0-1) unstable; urgency=low
 
   * Add HQAA chromosome read counts.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ataqv
 Section: science
 Priority: optional
 Maintainer: Parker Lab Software <parkerlab-software@umich.edu>
-Build-Depends: debhelper (>= 9), libboost-all-dev(>= 1.47), libhts-dev (>= 1.0), libncurses5-dev (>= 5.9), libstdc++-4.9-dev | libstdc++-5-dev | libstdc++-6-dev, libtinfo-dev (>= 5.9), zlib1g-dev (>= 1:1.1.4), lcov
+Build-Depends: debhelper (>= 9), libboost-all-dev(>= 1.47), libhts-dev (>= 1.0), libncurses5-dev (>= 5.9), libstdc++-4.9-dev | libstdc++-5-dev | libstdc++-6-dev | libstdc++-8-dev, libtinfo-dev (>= 5.9), zlib1g-dev (>= 1:1.1.4), lcov
 Standards-Version: 3.9.8
 Homepage: https://github.com/ParkerLab/ataqv/
 Vcs-Git: https://github.com/ParkerLab/ataqv.git

--- a/src/cpp/test_metrics.cpp
+++ b/src/cpp/test_metrics.cpp
@@ -156,7 +156,7 @@ TEST_CASE("Metrics::load_alignments", "[metrics/load_alignments]") {
 
     REQUIRE(metrics->peaks.size() == 37276);
 
-    REQUIRE(metrics->tss_enrichment == Approx(4.119850));
+    REQUIRE(metrics->tss_enrichment == Approx(6.0));
 
     nlohmann::json j = collector.to_json();
     unsigned long long int total_reads = j[0]["metrics"]["total_reads"];


### PR DESCRIPTION
Update Debian packaging for 1.1.1. Ensure static building and packaging works under Debian Buster. Stop signing source and changes in Debian packaging.

With the TSS calculation changes in 1.1.1 one test needed updating.

Also update Makefile to ensure "make test" requires Version.hpp so run_ataqv_tests can be built.